### PR TITLE
Enable IPv6 IPs filtering by adding a query named "ipv6"

### DIFF
--- a/src/client/repo.ts
+++ b/src/client/repo.ts
@@ -134,7 +134,7 @@ export const generateDefaultIPv4 = () => {
 
 export const getIPAll = async (
   { DATABASE: DB, LOSS_THRESHOLD = 10, DELAY_THRESHOLD = 500 }: Bindings,
-  randomName: boolean,
+  randomName: boolean, ipv6: boolean,
 ) => {
   const db = drizzle(DB)
   const rows = await db.select().from(tableIP).all()
@@ -150,6 +150,7 @@ export const getIPAll = async (
     }
   }).filter(({ loss, delay }) =>
     loss <= LOSS_THRESHOLD && delay <= DELAY_THRESHOLD)
+    .filter(({ ip }) => ipv6 || !ip.includes(":"))
 }
 
 function splitIpPort(address: string): [string, string] {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -26,12 +26,12 @@ app.get('/:subType',
   async (c) => {
     const {
       best, randomName,
-      proxyFormat,
+      proxyFormat, ipv6,
     } = c.req.valid('query')
     const { subType } = c.req.valid('param')
     const isAndroid = (c.req.header('user-agent') ?? '').includes('android')
     const { data, fileName } = await sub(
-      c.env, randomName, best, subType, proxyFormat, isAndroid)
+      c.env, randomName, best, subType, proxyFormat, isAndroid, ipv6)
     return c.newResponse(data, 200, {
       'Content-Disposition': `attachment; filename=${fileName}`
     })


### PR DESCRIPTION
Enable IPv6 IPs filtering by adding a query named "ipv6".
IPv6 ip will only be included in response if true and present in database.